### PR TITLE
moreblocks tar

### DIFF
--- a/asphalt/init.lua
+++ b/asphalt/init.lua
@@ -7,17 +7,32 @@ minetest.register_node(":streets:asphalt",{
 	groups	= {cracky=3}
 })
 
-if minetest.get_modpath("building_blocks") then
-	minetest.register_craft({
-		type = "shapeless",
-	    output = "streets:asphalt 3",
-	    recipe = {
-			"default:sand",
-			"default:gravel",
-			"building_blocks:Tar"
-	    },
-	})
-else
+-- different recipes for different mods. Unfortinnaly moreblocks tar and building_blocks tar have different names (tar and Tar). For better readability I divide recipes.
+local recipe_list={
+	building_blocks={
+				"default:sand",
+				"default:gravel",
+				"building_blocks:Tar"
+	},
+	moreblocks={
+				"default:sand",
+				"default:gravel",
+				"moreblocks:tar"
+	},
+}
+
+for mod, mod_recipe in pairs(recipe_list) do
+	if minetest.get_modpath(mod) then
+		minetest.register_craft({
+				type = "shapeless",
+				output = "streets:asphalt 3",
+				recipe = mod_recipe,
+			})
+	recipe_list.registred=1
+	end
+end
+
+if not not recipe_list.registred then
 	minetest.register_craft({
 		type = "cooking",
 		output	= "streets:asphalt",


### PR DESCRIPTION
Moreblocks mod have own recipe for crafting tar that same as recipe for crafting asphalt from gravel. So, we have to add some check for moreblocks. Unfortinnaly, moreblocks tar and building blocks tar have different names (Tar and tar)
